### PR TITLE
added test.yaml and lint.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,33 @@
+
+name: run-lints
+run-name: Linting for ${{ github.actor }}'s changes.
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Install pylint
+        run: pip install pylint
+
+      - name: Get changes to station_performance_pipeline
+        id: changed-station_performance_pipeline
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+             station_performance_pipeline/**.py
+
+      - name: Run station_performance_pipeline linting if files changed
+        if: steps.changed-station_performance_pipeline.outputs.any_changed == 'true'
+        run: |
+          pylint station_performance_pipeline/*.py --ignore-patterns=test_ --fail-under=8.5
+
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 jobs:
-  test_and_lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Added automated testing and linting which will be used to prevent the merging of breaking/poor quality code.

The lint threshold is 8.5 and linting will only measure the code quality of files in the directory that changed (to prevent the average pylint score being brought up by code that already passed the workflow).

Testing will be executed across all projects in the repo; this lets us make sure that changes in one microservice do not affect changes in another.