### PR TITLE
Fixed missed requirements installation in workflow file

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Run station_performance_pipeline linting if files changed
         if: steps.changed-station_performance_pipeline.outputs.any_changed == 'true'
         run: |
+          pip install -r station_performance_pipeline/requirements.txt
           pylint station_performance_pipeline/*.py --ignore-patterns=test_ --fail-under=8.5
 
 


### PR DESCRIPTION
lint.yaml was not working correctly as it was not detecting installed modules and thus lowering the score on this basis.

This PR adds the installation of requirements.txt which should fix this issue.