### PR TITLE
[Bug] Update schema to use lowercase and _ style rather than using capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ terraform destroy
 
 ### ERD diagram
 
-![ERD diagram](https://drawsql.app/teams/isaac-11/diagrams/railway-tracker-3)
+[ERD diagram](https://drawsql.app/teams/trainee-4/diagrams/copy-of-railway-tracker)
 
-![image](https://github.com/adamski201/Railway-Tracker/assets/84942651/9e6dc207-77bf-41b4-b83a-ae77c5825deb)
+![image](https://github.com/adamski201/Railway-Tracker/assets/84942651/60dab6de-ab46-4a31-8076-2c2c07dfc0b2)
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ terraform destroy
 
 ![ERD diagram](https://drawsql.app/teams/isaac-11/diagrams/railway-tracker-3)
 
-<img width="1250" alt="Screenshot 2024-04-24 at 17 03 52" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/fb1fb8fc-6a11-4cb5-a222-69a738afcb33">
+![image](https://github.com/adamski201/Railway-Tracker/assets/84942651/9e6dc207-77bf-41b4-b83a-ae77c5825deb)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ terraform destroy
 
 ![ERD diagram](https://drawsql.app/teams/isaac-11/diagrams/railway-tracker-3)
 
-<img width="927" alt="Screenshot 2024-04-24 at 10 42 59" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/3c3c4002-312a-4a3d-8d2a-b58113188071">
+<img width="1108" alt="Screenshot 2024-04-24 at 16 53 04" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/c7f4da53-212b-44ca-b239-f51d9109b8b6">
+
 
 
 ### Cloud architecture diagram

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ terraform destroy
 
 ![ERD diagram](https://drawsql.app/teams/isaac-11/diagrams/railway-tracker-3)
 
-<img width="1108" alt="Screenshot 2024-04-24 at 16 53 04" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/c7f4da53-212b-44ca-b239-f51d9109b8b6">
+<img width="1250" alt="Screenshot 2024-04-24 at 17 03 52" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/fb1fb8fc-6a11-4cb5-a222-69a738afcb33">
 
 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ terraform destroy
 
 ### ERD diagram
 
-![ERD diagram](...)
+![ERD diagram](https://drawsql.app/teams/isaac-11/diagrams/railway-tracker-3)
+
+<img width="927" alt="Screenshot 2024-04-24 at 10 42 59" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/3c3c4002-312a-4a3d-8d2a-b58113188071">
+
 
 ### Cloud architecture diagram
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ terraform destroy
 
 ### ERD diagram
 
-[ERD diagram](https://drawsql.app/teams/trainee-4/diagrams/copy-of-railway-tracker)
+[ERD diagram](https://drawsql.app/teams/trainee-4/diagrams/railway-tracker-3nf)
 
 ![image](https://github.com/adamski201/Railway-Tracker/assets/84942651/60dab6de-ab46-4a31-8076-2c2c07dfc0b2)
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE users (
     first_name VARCHAR(30) NOT NULL,
     last_name VARCHAR(60) NOT NULL,
     phone_number VARCHAR(20),
-    email VARCHAR
+    email VARCHAR(320)
 );
 
 CREATE TABLE station_subscriptions (
@@ -84,5 +84,5 @@ CREATE TABLE incidents (
     affected_routes TEXT,
     planned BOOLEAN NOT NULL,
     incident_uuid VARCHAR(32) UNIQUE NOT NULL,
-    last_updated TIMESTAMP
+    last_updated TIMESTAMP NOT NULL
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -9,6 +9,7 @@ DROP TABLE IF EXISTS services;
 DROP TABLE IF EXISTS operators;
 DROP TABLE IF EXISTS stations;
 
+
 CREATE TABLE stations (
     station_id SERIAL PRIMARY KEY,
     crs_code VARCHAR(3) UNIQUE NOT NULL,
@@ -72,7 +73,7 @@ CREATE TABLE operator_subscriptions (
 );
 
 CREATE TABLE incidents (
-    incident_record_id SERIAL PRIMARY KEY,
+    incident_id SERIAL PRIMARY KEY,
     operator_id INT REFERENCES operators(operator_id),
     creation_date TIMESTAMP NOT NULL,
     description TEXT,
@@ -82,6 +83,6 @@ CREATE TABLE incidents (
     info_link TEXT,
     affected_routes TEXT,
     planned BOOLEAN NOT NULL,
-    incident_number VARCHAR(32) UNIQUE NOT NULL,
+    incident_uuid VARCHAR(32) UNIQUE NOT NULL,
     last_updated TIMESTAMP
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,88 +1,87 @@
-DROP TABLE Incidents;
-DROP TABLE OperatorSubscriptions;
-DROP TABLE StationSubscriptions;
-DROP TABLE Users;
-DROP TABLE Arrivals;
-DROP TABLE Cancellations;
-DROP TABLE CancellationTypes;
-DROP TABLE Services;
-DROP TABLE Operators;
-DROP TABLE Stations;
+DROP TABLE IF EXISTS incidents;
+DROP TABLE IF EXISTS operator_subscriptions;
+DROP TABLE IF EXISTS station_subscriptions;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS arrivals;
+DROP TABLE IF EXISTS cancellations;
+DROP TABLE IF EXISTS cancellation_types;
+DROP TABLE IF EXISTS services;
+DROP TABLE IF EXISTS operators;
+DROP TABLE IF EXISTS stations;
 
-
-CREATE TABLE Stations(
-    StationID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, 
-    CRSCode varchar(3) UNIQUE NOT NULL,
-    StationName varchar(60) NOT NULL
+CREATE TABLE stations (
+    station_id SERIAL PRIMARY KEY,
+    crs_code VARCHAR(3) UNIQUE NOT NULL,
+    station_name VARCHAR(60) NOT NULL
 );
 
-CREATE TABLE Operators(
-    OperatorID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, 
-    OperatorName varchar(60) NOT NULL,
-    OperatorCode varchar(2) UNIQUE
+CREATE TABLE operators (
+    operator_id SERIAL PRIMARY KEY,
+    operator_name VARCHAR(60) NOT NULL,
+    operator_code VARCHAR(2) UNIQUE
 );
 
-CREATE TABLE Services(
-    ServiceID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    ServiceUID varchar(6) UNIQUE NOT NULL,
-    OperatorID INT REFERENCES Operators(OperatorID)
+CREATE TABLE services (
+    service_id SERIAL PRIMARY KEY,
+    service_uid VARCHAR(6) UNIQUE NOT NULL,
+    operator_id INT REFERENCES operators(operator_id)
 );
 
-CREATE TABLE CancellationTypes(
-    CancellationTypeID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    CancellationCode varchar(2) UNIQUE NOT NULL,
-    Description text
+CREATE TABLE cancellation_types (
+    cancellation_type_id SERIAL PRIMARY KEY,
+    cancellation_code VARCHAR(2) UNIQUE NOT NULL,
+    description TEXT
 );
 
-CREATE TABLE Cancellations(
-    CancellationID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    ScheduledArrival timestamp NOT NULL,
-    CancellationTypeID INT REFERENCES CancellationTypes(CancellationTypeID),
-    StationID INT REFERENCES Stations(StationID),
-    ServiceID INT REFERENCES Services(ServiceID)
+CREATE TABLE cancellations (
+    cancellation_id SERIAL PRIMARY KEY,
+    scheduled_arrival TIMESTAMP NOT NULL,
+    cancellation_type_id INT REFERENCES cancellation_types(cancellation_type_id),
+    station_id INT REFERENCES stations(station_id),
+    service_id INT REFERENCES services(service_id)
 );
 
-CREATE TABLE Arrivals(
-    ArrivalID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    ScheduledArrival timestamp NOT NULL,
-    ActualArrival timestamp NOT NULL,
-    StationID INT REFERENCES Stations(StationID),
-    ServiceID INT REFERENCES Services(ServiceID)
+CREATE TABLE arrivals (
+    arrival_id SERIAL PRIMARY KEY,
+    scheduled_arrival TIMESTAMP NOT NULL,
+    actual_arrival TIMESTAMP NOT NULL,
+    station_id INT REFERENCES stations(station_id),
+    service_id INT REFERENCES services(service_id)
 );
 
-CREATE TABLE Users(
-    UserID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    FirstName varchar(30) NOT NULL,
-    LastName varchar(60) NOT NULL,
-    PhoneNumber varchar(20),
-    Email varchar
+CREATE TABLE users (
+    user_id SERIAL PRIMARY KEY,
+    first_name VARCHAR(30) NOT NULL,
+    last_name VARCHAR(60) NOT NULL,
+    phone_number VARCHAR(20),
+    email VARCHAR
 );
 
-CREATE TABLE StationSubscriptions(
-    StationSubscriptionID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    IsActive BOOLEAN NOT NULL,
-    UserID INT REFERENCES Users(UserID),
-    StationID INT REFERENCES Stations(StationID)
+CREATE TABLE station_subscriptions (
+    station_subscription_id SERIAL PRIMARY KEY,
+    is_active BOOLEAN NOT NULL,
+    user_id INT REFERENCES users(user_id),
+    station_id INT REFERENCES stations(station_id)
 );
 
-CREATE TABLE OperatorSubscriptions(
-    OperatorSubscriptionID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    IsActive BOOLEAN NOT NULL,
-    UserID INT REFERENCES Users(UserID),
-    OperatorID INT REFERENCES Operators(OperatorID)
+CREATE TABLE operator_subscriptions (
+    operator_subscription_id SERIAL PRIMARY KEY,
+    is_active BOOLEAN NOT NULL,
+    user_id INT REFERENCES users(user_id),
+    operator_id INT REFERENCES operators(operator_id)
 );
 
-CREATE TABLE Incidents(
-    IncidentRecordID INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    OperatorID INT REFERENCES Operators(OperatorID),
-    CreationDate timestamp NOT NULL, 
-    Description text,
-    Summary text, 
-    StartDate timestamp NOT NULL,
-    EndDate timestamp,
-    InfoLink text,
-    AffectedRoutes text,
-    Planned BOOLEAN NOT NULL,
-    IncidentNumber varchar(32) UNIQUE NOT NULL,
-    LastUpdated timestamp
+CREATE TABLE incidents (
+    incident_record_id SERIAL PRIMARY KEY,
+    operator_id INT REFERENCES operators(operator_id),
+    creation_date TIMESTAMP NOT NULL,
+    description TEXT,
+    summary TEXT,
+    start_date TIMESTAMP NOT NULL,
+    end_date TIMESTAMP,
+    info_link TEXT,
+    affected_routes TEXT,
+    planned BOOLEAN NOT NULL,
+    incident_number VARCHAR(32) UNIQUE NOT NULL,
+    last_updated TIMESTAMP
 );


### PR DESCRIPTION
As PSQL does not use capitalisation, our previous database schema lost its readability as all table/attribute names became lowercase with no spacing e.g. ServiceUUID became serviceuuid. Using this new style we can regain readability (service_uuid). 

This PR modifies the schema.sql script to reflect this. 

Closes #46 