### PR TITLE
Added a precaution measure to initialise_tables.sh script

### DIFF
--- a/database/initialise_tables.sh
+++ b/database/initialise_tables.sh
@@ -1,4 +1,4 @@
-read -p "Are you sure you want to run this script? (y/n): " confirm
+read -p "This will wipe the database! Are you sure you want to run this script? (y/n): " confirm
 if [ "$confirm" != "y" ]; then
     echo "Script execution aborted."
     exit 1

--- a/database/initialise_tables.sh
+++ b/database/initialise_tables.sh
@@ -1,3 +1,9 @@
+read -p "Are you sure you want to run this script? (y/n): " confirm
+if [ "$confirm" != "y" ]; then
+    echo "Script execution aborted."
+    exit 1
+fi
+
 source .env
 export PGPASSWORD=$DB_PASS
 psql -h $DB_HOST -p $DB_PORT -U $DB_USER $DB_NAME -f schema.sql


### PR DESCRIPTION
Before this PR, if we were to run 'sh initialise_tables.sh' in the terminal, the database (related to your environment variables) would be instantly wiped. 
In #50,  I mentioned how this could accidentally be done. 
I've added some extra code to the bash script that asks the user to verify whether they want to run the script or not.

When testing it out I changed the value of DB_HOST=aaa rather than the actual host of the RDS. Here's how it looks when you run 'sh initialise_tables.sh' in the terminal:

<img width="767" alt="Screenshot 2024-04-25 at 13 16 43" src="https://github.com/adamski201/Railway-Tracker/assets/84942651/183593c3-50ce-46ce-9941-ef9fd827f4cb">

In the first two calls, I type 'd' and 'n' which abort the script since they're not 'y'.
In the third call, I type 'y' and it proceeds to run the restarting the database part of the script (in this case it throws up an error because I put an invalid DB_HOST - but if it were an actual value corresponding to a database, it would clear that database).