### PR TITLE
Added new schema to database

### DIFF
--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -6,8 +6,8 @@ CREATE TABLE historical_data.station_performance(
     station_id INT REFERENCES public.stations(station_id),
     day DATE NOT NULL,
     cancellation_count INT DEFAULT 0,
-    delay_1m_count INT NOT DEFAULT 0, 
-    delay_5m_count INT NOT DEFAULT 0, 
+    delay_1m_count INT DEFAULT 0, 
+    delay_5m_count INT DEFAULT 0, 
     avg_delay DECIMAL(4,2) DEFAULT 0,
     arrival_count INT NOT NULL, 
     common_cancel_code varchar(2) 

--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -1,24 +1,26 @@
+DROP TABLE IF EXISTS historical_data.station_performance;
+DROP TABLE IF EXISTS historical_data.operator_performance;
 
 CREATE TABLE historical_data.station_performance(
     station_performance_id SERIAL PRIMARY KEY,
-    station_id INT REFERENCES historical_schema.stations(station_id),
-    date TIMESTAMP NOT NULL,
+    station_id INT REFERENCES public.stations(station_id),
+    day TIMESTAMP NOT NULL,
     cancellation_count INT NOT NULL,
     delay_1m_count INT NOT NULL, 
     delay_5m_count INT NOT NULL, 
     avg_delay DECIMAL(4,2) NOT NULL,
     arrival_count INT NOT NULL, 
     common_cancel_code varchar(2) 
-)
+);
 
 CREATE TABLE historical_data.operator_performance(
     operator_performance_id SERIAL PRIMARY KEY,
-    operator_id INT REFERENCES historical_schema.operators(operator_id),
-    date TIMESTAMP NOT NULL,
+    operator_id INT REFERENCES public.operators(operator_id),
+    day TIMESTAMP NOT NULL,
     cancellation_count INT NOT NULL,
     delay_1m_count INT NOT NULL, 
     delay_5m_count INT NOT NULL, 
     avg_delay DECIMAL(4,2) NOT NULL,
     arrival_count INT NOT NULL, 
     common_cancel_code varchar(2) 
-)
+);

--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -1,0 +1,24 @@
+
+CREATE TABLE historical_data.station_performance(
+    station_performance_id SERIAL PRIMARY KEY,
+    station_id INT REFERENCES historical_schema.stations(station_id),
+    date TIMESTAMP NOT NULL,
+    cancellation_count INT NOT NULL,
+    delay_1m_count INT NOT NULL, 
+    delay_5m_count INT NOT NULL, 
+    avg_delay DECIMAL(4,2) NOT NULL,
+    arrival_count INT NOT NULL, 
+    common_cancel_code varchar(2) 
+)
+
+CREATE TABLE historical_data.operator_performance(
+    operator_performance_id SERIAL PRIMARY KEY,
+    operator_id INT REFERENCES historical_schema.operators(operator_id),
+    date TIMESTAMP NOT NULL,
+    cancellation_count INT NOT NULL,
+    delay_1m_count INT NOT NULL, 
+    delay_5m_count INT NOT NULL, 
+    avg_delay DECIMAL(4,2) NOT NULL,
+    arrival_count INT NOT NULL, 
+    common_cancel_code varchar(2) 
+)

--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -4,7 +4,7 @@ DROP TABLE IF EXISTS historical_data.operator_performance;
 CREATE TABLE historical_data.station_performance(
     station_performance_id SERIAL PRIMARY KEY,
     station_id INT REFERENCES public.stations(station_id),
-    day TIMESTAMP NOT NULL,
+    day DATE NOT NULL,
     cancellation_count INT NOT NULL,
     delay_1m_count INT NOT NULL, 
     delay_5m_count INT NOT NULL, 
@@ -16,7 +16,7 @@ CREATE TABLE historical_data.station_performance(
 CREATE TABLE historical_data.operator_performance(
     operator_performance_id SERIAL PRIMARY KEY,
     operator_id INT REFERENCES public.operators(operator_id),
-    day TIMESTAMP NOT NULL,
+    day DATE NOT NULL,
     cancellation_count INT NOT NULL,
     delay_1m_count INT NOT NULL, 
     delay_5m_count INT NOT NULL, 

--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -5,10 +5,10 @@ CREATE TABLE historical_data.station_performance(
     station_performance_id SERIAL PRIMARY KEY,
     station_id INT REFERENCES public.stations(station_id),
     day DATE NOT NULL,
-    cancellation_count INT NOT NULL,
-    delay_1m_count INT NOT NULL, 
-    delay_5m_count INT NOT NULL, 
-    avg_delay DECIMAL(4,2) NOT NULL,
+    cancellation_count INT DEFAULT 0,
+    delay_1m_count INT NOT DEFAULT 0, 
+    delay_5m_count INT NOT DEFAULT 0, 
+    avg_delay DECIMAL(4,2) DEFAULT 0,
     arrival_count INT NOT NULL, 
     common_cancel_code varchar(2) 
 );
@@ -17,10 +17,10 @@ CREATE TABLE historical_data.operator_performance(
     operator_performance_id SERIAL PRIMARY KEY,
     operator_id INT REFERENCES public.operators(operator_id),
     day DATE NOT NULL,
-    cancellation_count INT NOT NULL,
-    delay_1m_count INT NOT NULL, 
-    delay_5m_count INT NOT NULL, 
-    avg_delay DECIMAL(4,2) NOT NULL,
+    cancellation_count INT DEFAULT 0,
+    delay_1m_count INT DEFAULT 0, 
+    delay_5m_count INT DEFAULT 0, 
+    avg_delay DECIMAL(4,2) DEFAULT 0,
     arrival_count INT NOT NULL, 
     common_cancel_code varchar(2) 
 );

--- a/database/initialise_historical_tables.sh
+++ b/database/initialise_historical_tables.sh
@@ -1,0 +1,9 @@
+read -p "This will wipe the historical_data schema in the database! Are you sure you want to run this script? (y/n): " confirm
+if [ "$confirm" != "y" ]; then
+    echo "Script execution aborted."
+    exit 1
+fi
+
+source .env
+export PGPASSWORD=$DB_PASS
+psql -h $DB_HOST -p $DB_PORT -U $DB_USER $DB_NAME -f historical_schema.sql


### PR DESCRIPTION
Added two new files: 
1. historical_schema.sql - A sql script designed to initialise a new historical_data schema in a database.
2. initialise_historical_tables.sh - A bash script to run the historical_schema.sql script in a database (It assumes that the database you use in your environment variables has a schema named historical_schema.

To run initialise_historical_tables.sh, you need the following environment variables:
DB_HOST=XXXXXXXX
DB_PORT=XXXXXXXX
DB_USER=XXXXXXXX
DB_PASS=XXXXXXXX
DB_NAME=XXXXXXXX